### PR TITLE
fix: resolve Markdown linting issues, broken link to Cirq image, and improve structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,29 @@
 
 - 💬 Ask me about **Quantum Computing, Machine Learning, Deep Learning!**
 
-- 📫 How to reach me **mlpython0@gmail.com**
+- 📫 How to reach me **<mlpython0@gmail.com>**
 
 - ⚡ Fun fact **I am a published sci-fi writer!**
 
-<h3 align="left">Connect with me:</h3>
+### Connect with me
+
 <p align="left">
 <a href="https://linkedin.com/in/jay-shah-qml" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="jay-shah-qml" height="30" width="40" /></a>
 <a href="https://www.youtube.com/c/blochsphere" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/youtube.svg" alt="blochsphere" height="30" width="40" /></a>
 </p>
 
-<h3 align="left">Languages and Tools:</h3>
+### Languages and Tools
+
 <p align="left"> <a href="https://www.python.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/> </a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="javascript" width="40" height="40"/> </a> </p>
 
 <p align="left"> <a href="https://www.tensorflow.org" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/tensorflow/tensorflow-icon.svg" alt="tensorflow" width="40" height="40"/> </a> <a href="https://pytorch.org/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/pytorch/pytorch-icon.svg" alt="pytorch" width="40" height="40"/> </a> <a href="https://angular.io" target="_blank" rel="noreferrer"> <img src="https://angular.io/assets/images/logos/angular/angular.svg" alt="angular" width="40" height="40"/> </a> <a href="https://reactjs.org/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original-wordmark.svg" alt="react" width="40" height="40"/> </a></p>
 
-<h3 align="left">Quantum Tools:</h3>
+### Quantum Tools
 
-<a href="https://qiskit.org/" target="_blank" rel="noreferrer"> <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSZ-5q-sm3skVUUkXufUO8dgL7c3BMU5aWvMyBRD-M3roB-nC7EzP5rZfBjUpJijnig2WI&usqp=CAU" alt="qiskit" width="140" height="80"/> </a> <a href="https://pennylane.ai/" target="_blank" rel="noreferrer"> <img src="https://pbs.twimg.com/media/FYmCwpqWIAA_EUU.jpg:large" alt="pennylane" width="140" height="80"/> </a> 
+<a href="https://qiskit.org/" target="_blank" rel="noreferrer"> <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSZ-5q-sm3skVUUkXufUO8dgL7c3BMU5aWvMyBRD-M3roB-nC7EzP5rZfBjUpJijnig2WI&usqp=CAU" alt="qiskit" width="106" height="80"/> </a> <a href="https://pennylane.ai/" target="_blank" rel="noreferrer"> <img src="https://pbs.twimg.com/media/FYmCwpqWIAA_EUU.jpg:large" alt="pennylane" width="142" height="80"/> </a> 
 
-<a href="https://quantumai.google/cirq" target="_blank" rel="noreferrer"> <img src="https://repository-images.githubusercontent.com/114306758/2566b800-6601-11e9-9f2d-36d3354da949" alt="cirq" width="80" height="40"/> </a>
+<a href="https://quantumai.google/cirq" target="_blank" rel="noreferrer"> <img src="https://quantumai.google/static/site-assets/images/marketing/icons/shared-ic-cirq.png" alt="cirq" width="50" height="50"/> </a>
 
-<h3 align="left">Support:</h3>
-<p><a href="https://www.buymeacoffee.com/BlochSphere"> <img align="left" src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" height="50" width="210" alt="BlochSphere" /></a></p><br><br>
+### Support
 
+<a href="https://www.buymeacoffee.com/BlochSphere"> <img align="left" src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" height="50" width="210" alt="BlochSphere" /></a>


### PR DESCRIPTION
This pull request addresses multiple Markdown linting issues and improves the structure of the `README.md` file. The following fixes have been implemented:

-  Fixes broken image link for Cirq, replacing the previous invalid URL.
- **MD033/no-inline-html:** Removed `<h3>` elements while maintaining the original structure.
- **MD026/no-trailing-punctuation:** Removed colons (`:`) in headings.
- **MD034/no-bare-urls:** Replaced bare email URLs using angle brackets.
- **MD012/no-multiple-blanks:** Removed unnecessary blank lines.
- **Buy Me a Coffee Section:** Removed unnecessary `</p><br><br>` tags.
-  **Image Aspect Ratio Fixes:**
    - Adjusted **Qiskit** image to `width: 106px`, `height: 80px`.
   - Adjusted **PennyLane** image to `width: 142px`, `height: 80px`.

The commit:

- Ensures Markdown compatibility with GitHub.
- Improves code readability and formatting consistency.
- Adheres to best practices for Markdown linting.
- Maintain the same README visual style.
